### PR TITLE
feat(web): improve autocomplete

### DIFF
--- a/boiler-grades-web/src/components/SearchBar.vue
+++ b/boiler-grades-web/src/components/SearchBar.vue
@@ -9,6 +9,7 @@
         :loading="loading"
         :items="items"
         :search-input.sync="search"
+        :filter="filter"
         label="Search by class or instructor"
         class="mb-n4"
     >
@@ -81,6 +82,13 @@ export default {
     },
     
     methods: {
+        filter(item, queryText, itemText) {
+            const testExp = new RegExp(
+                `.*${queryText.split("").join(".*")}.*`,
+                "i"
+            )
+            return testExp.test(itemText)
+        },
         getItems() {
             fetch('/api/indexes')
                 .then(res => res.json())


### PR DESCRIPTION
I expect that this change would increase usability by:
* allowing minor typo
* giving flexibility to input comma(`,`) or space(` `)

Idea:
* loosen auto-complete rule

e.g.,
![image](https://user-images.githubusercontent.com/72803908/186027853-73c1fab3-2bf5-4a8b-aee0-cbc715ba67e6.png)

As shown in the picture, it matches strings as `/.*z.*a.*n.*w.*a.*n.*/i`